### PR TITLE
feat: package.jsonの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+*.db
+build/
+*.log
+*.lock

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oshavery-server",
   "version": "0.0.1",
   "description": "Oshavery ServerSide Project",
-  "main": "index.js",
+  "main": "main.js",
   "repository": "https://github.com/undecided-discord/oshavery-server",
   "author": "Undecided Oshavery Development Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "oshavery-server",
+  "version": "0.0.1",
+  "description": "Oshavery ServerSide Project",
+  "main": "index.js",
+  "repository": "https://github.com/undecided-discord/oshavery-server",
+  "author": "Undecided Oshavery Development Team",
+  "license": "MIT",
+  "scripts": {
+    "start": "npx tsc -p . && node ./build/main.js"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.13",
+    "@types/node": "^16.7.1",
+    "ts-node": "^10.2.1",
+    "typescript": "^4.3.5"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compileOnSave": true,
+    "compilerOptions": {
+      "target": "es2019",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+      "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+      "outDir": "./build",                              /* Redirect output structure to the directory. */
+      "rootDir": "./src",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+      "removeComments": true,                      /* Do not emit comments to output. */
+      "strict": true,                                 /* Enable all strict type-checking options. */
+      "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+      "noUnusedLocals": false,                      /* Report errors on unused locals. */
+      "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+      "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+      "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+      "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+      "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+      "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    }
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,4 +16,4 @@
       "skipLibCheck": true,                           /* Skip type checking of declaration files. */
       "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
     }
-  }
+}


### PR DESCRIPTION
- [feat] TypeScript の環境構築
- [fix] package.jsonに記載するファイル名の表記ゆれの修正

package.jsonの`script`のファイル名と`main` のファイル名が違ったので修正

これ以降は`src/main.ts`が本体になります

