### PR TITLE
refactor: WebSocket APIで認証を要求するように

### DIFF
--- a/src/controllers/notificationcontroller.ts
+++ b/src/controllers/notificationcontroller.ts
@@ -1,20 +1,15 @@
 import WebSocket from "ws";
-// import { guild } from "../models/guild";
+import {
+  notification,
+  opeChannelBody,
+  opeMessageBody,
+  opeUserBody,
+} from "../types/notification_types";
 
 const wss = new WebSocket.Server({ port: 8080 });
 
-// 資料が少ないため実装は間違ってると思われる
-// というか絶対間違っているので再実装必須
-
-interface opeChannel {
-  type: string;
-  body: {
-    channelId: string;
-  };
-}
-
 async function channel(type: string, channelId: string) {
-  const channel: opeChannel = {
+  const channel: notification<opeChannelBody> = {
     type,
     body: {
       channelId,
@@ -26,16 +21,8 @@ async function channel(type: string, channelId: string) {
   });
 }
 
-interface opeMessage {
-  type: string;
-  body: {
-    channelId: string;
-    messageId: string;
-  };
-}
-
 async function message(type: string, channelId: string, messageId: string) {
-  const message: opeMessage = {
+  const message: notification<opeMessageBody> = {
     type,
     body: {
       channelId,
@@ -48,16 +35,8 @@ async function message(type: string, channelId: string, messageId: string) {
   });
 }
 
-interface opeUser {
-  type: string;
-  body: {
-    userId: string;
-    guildId: string;
-  };
-}
-
 async function user(type: string, userId: string, guildId: string) {
-  const user: opeUser = {
+  const user: notification<opeUserBody> = {
     type,
     body: {
       userId,

--- a/src/init/seed.ts
+++ b/src/init/seed.ts
@@ -14,6 +14,7 @@ async function seed() {
       bot: true,
       origin: "",
       avatarurl: "",
+      password: "$2a$10$S75zuQxZMbbiWW4UCMjjYeSA3y9UKzGwwNQ7zeGSRhGrvw5Vl3vjm",
       sub: "oshavery|0",
     },
   });
@@ -29,6 +30,7 @@ async function seed() {
       bot: true,
       origin: "",
       avatarurl: "",
+      password: "$2a$10$S75zuQxZMbbiWW4UCMjjYeSA3y9UKzGwwNQ7zeGSRhGrvw5Vl3vjm",
       sub: "oshavery|1",
     },
   });

--- a/src/routes/channel.ts
+++ b/src/routes/channel.ts
@@ -17,7 +17,7 @@ export async function ChannelRouter(server: FastifyInstance) {
     createChannel
   );
 
-  await server.post<{ Params: GuildIdParam; Body: UpdateChannel }>(
+  await server.patch<{ Params: GuildIdParam; Body: UpdateChannel }>(
     "/guilds/:guildId/channels",
     updateChannel
   );

--- a/src/types/notification_types.ts
+++ b/src/types/notification_types.ts
@@ -1,0 +1,20 @@
+export type notification<
+  T extends opeChannelBody | opeMessageBody | opeUserBody
+> = {
+  type: string;
+  body: T;
+};
+
+export type opeChannelBody = {
+  channelId: string;
+};
+
+export type opeMessageBody = {
+  channelId: string;
+  messageId: string;
+};
+
+export type opeUserBody = {
+  userId: string;
+  guildId: string;
+};


### PR DESCRIPTION
close #143 

## 変更概要
- routerでhttpメソッドの指定ミスがあったので修正
- seedが正常に動かないのを修正
- WebSocket APIで認証を要求するように

## 詳細
WebSocket APIへの接続方法が変わります
`ws://<host>:<port>/?token=<access_token>`
末尾に通常のAPIのアクセストークンを付けてください(付けない場合は接続できません)